### PR TITLE
Style ready to start section tablet layout

### DIFF
--- a/src/about.html
+++ b/src/about.html
@@ -85,10 +85,16 @@
 
     <section class="container ready-to-start__section">
       <h2>Ready to start?</h2>
-      <form>
-        <input type="email" placeholder="Enter email address" aria-label="email" class="form__input form__input--email"/>
-        <input type="submit" value="Schedule a Demo" aria-label="submit" class="form__input form__input--btn" />
-      </form>
+      <div class="ready-to-start__form-wrapper">
+        <form class="ready-to-start__form">
+          <div class="ready-to-start__form-input">
+            <input type="email" placeholder="Enter email address" aria-label="email" class="form__input  form__input--email form__input--ready-to-start-email"/>
+          </div>
+          <div class="ready-to-start__form-input">
+            <input type="submit" value="Schedule a Demo" aria-label="submit" class="form__input form__input--btn form__input--ready-to-start-btn" />
+          </div>
+        </form>      
+      </div>
     </section>
 
     <footer>

--- a/src/contact.html
+++ b/src/contact.html
@@ -90,10 +90,16 @@
 
     <section class="container ready-to-start__section">
       <h2>Ready to start?</h2>
-      <form>
-        <input type="email" placeholder="Enter email address" aria-label="email" class="form__input form__input--email"/>
-        <input type="submit" value="Schedule a Demo" aria-label="submit" class="form__input form__input--btn" />
-      </form>
+      <div class="ready-to-start__form-wrapper">
+        <form class="ready-to-start__form">
+          <div class="ready-to-start__form-input">
+            <input type="email" placeholder="Enter email address" aria-label="email" class="form__input  form__input--email form__input--ready-to-start-email"/>
+          </div>
+          <div class="ready-to-start__form-input">
+            <input type="submit" value="Schedule a Demo" aria-label="submit" class="form__input form__input--btn form__input--ready-to-start-btn" />
+          </div>
+        </form>      
+      </div>
     </section>
 
     <footer> 

--- a/src/index.html
+++ b/src/index.html
@@ -149,10 +149,10 @@
       <h2>Ready to start?</h2>
       <form class="ready-to-start__form">
         <div class="ready-to-start__form-input">
-          <input type="email" placeholder="Enter email address" aria-label="email" class="form__input  form__input--email form__input--ready-to-start"/>
+          <input type="email" placeholder="Enter email address" aria-label="email" class="form__input  form__input--email form__input--ready-to-start-email"/>
         </div>
         <div class="ready-to-start__form-input">
-          <input type="submit" value="Schedule a Demo" aria-label="submit" class="form__input form__input--btn form__input--ready-to-start" />
+          <input type="submit" value="Schedule a Demo" aria-label="submit" class="form__input form__input--btn form__input--ready-to-start-btn" />
         </div>
       </form>
     </section>

--- a/src/index.html
+++ b/src/index.html
@@ -155,8 +155,7 @@
           <div class="ready-to-start__form-input">
             <input type="submit" value="Schedule a Demo" aria-label="submit" class="form__input form__input--btn form__input--ready-to-start-btn" />
           </div>
-        </form>
-        
+        </form>      
       </div>
     </section>
   

--- a/src/index.html
+++ b/src/index.html
@@ -147,14 +147,17 @@
     
     <section class="container ready-to-start__section">
       <h2>Ready to start?</h2>
-      <form class="ready-to-start__form">
-        <div class="ready-to-start__form-input">
-          <input type="email" placeholder="Enter email address" aria-label="email" class="form__input  form__input--email form__input--ready-to-start-email"/>
-        </div>
-        <div class="ready-to-start__form-input">
-          <input type="submit" value="Schedule a Demo" aria-label="submit" class="form__input form__input--btn form__input--ready-to-start-btn" />
-        </div>
-      </form>
+      <div class="ready-to-start__form-wrapper">
+        <form class="ready-to-start__form">
+          <div class="ready-to-start__form-input">
+            <input type="email" placeholder="Enter email address" aria-label="email" class="form__input  form__input--email form__input--ready-to-start-email"/>
+          </div>
+          <div class="ready-to-start__form-input">
+            <input type="submit" value="Schedule a Demo" aria-label="submit" class="form__input form__input--btn form__input--ready-to-start-btn" />
+          </div>
+        </form>
+        
+      </div>
     </section>
   
     <footer> 

--- a/src/index.html
+++ b/src/index.html
@@ -147,9 +147,13 @@
     
     <section class="container ready-to-start__section">
       <h2>Ready to start?</h2>
-      <form>
-        <input type="email" placeholder="Enter email address" aria-label="email" class="form__input form__input--email"/>
-        <input type="submit" value="Schedule a Demo" aria-label="submit" class="form__input form__input--btn" />
+      <form class="ready-to-start__form">
+        <div class="ready-to-start__form-input">
+          <input type="email" placeholder="Enter email address" aria-label="email" class="form__input  form__input--email form__input--ready-to-start"/>
+        </div>
+        <div class="ready-to-start__form-input">
+          <input type="submit" value="Schedule a Demo" aria-label="submit" class="form__input form__input--btn form__input--ready-to-start" />
+        </div>
       </form>
     </section>
   

--- a/src/pricing.html
+++ b/src/pricing.html
@@ -150,14 +150,18 @@
         <a href="#" class="plan__btn">Request Access</a>
       </section>
 
-      
-
-      <section class="ready-to-start__section">
+      <section class="container ready-to-start__section">
         <h2>Ready to start?</h2>
-        <form>
-          <input type="email" placeholder="Enter email address" aria-label="email" class="form__input form__input--email"/>
-          <input type="submit" value="Schedule a Demo" aria-label="submit" class="form__input form__input--btn" />
-        </form>
+        <div class="ready-to-start__form-wrapper">
+          <form class="ready-to-start__form">
+            <div class="ready-to-start__form-input">
+              <input type="email" placeholder="Enter email address" aria-label="email" class="form__input  form__input--email form__input--ready-to-start-email"/>
+            </div>
+            <div class="ready-to-start__form-input">
+              <input type="submit" value="Schedule a Demo" aria-label="submit" class="form__input form__input--btn form__input--ready-to-start-btn" />
+            </div>
+          </form>      
+        </div>
       </section>
     </div>
     

--- a/src/styles.css
+++ b/src/styles.css
@@ -547,7 +547,7 @@ a {
     padding-bottom: 5em;
 }
 
-.ready-to-start__section form {
+.ready-to-start__form {
     margin: 0 auto;
     width: 100%;
     display: flex;
@@ -557,8 +557,23 @@ a {
     outline: unset;
 }
 
+.form__input--ready-to-start {
+    width: 100%;
+}
+
 .ready-to-start__section input:focus {
     outline: none;
+}
+
+@media screen and (min-width: 768px) {
+    .ready-to-start__form {
+        flex-direction: row;
+        justify-content: center;
+    }
+
+    .form__input--ready-to-start-email {
+        padding-right: 17em;
+    }
 }
 
 /* ====================

--- a/src/styles.css
+++ b/src/styles.css
@@ -547,6 +547,10 @@ a {
     padding-bottom: 5em;
 }
 
+.ready-to-start__form-wrapper {
+   width: 100%;
+}
+
 .ready-to-start__form {
     margin: 0 auto;
     width: 100%;
@@ -557,7 +561,11 @@ a {
     outline: unset;
 }
 
-.form__input--ready-to-start {
+.ready-to-start__form-input {
+    width: 100%;
+}
+
+.form__input--ready-to-start-email, .form__input--ready-to-start-btn {
     width: 100%;
 }
 
@@ -566,13 +574,36 @@ a {
 }
 
 @media screen and (min-width: 768px) {
+   
     .ready-to-start__form {
         flex-direction: row;
-        justify-content: center;
+        justify-content: center;    
+        max-width: 445px;
+        position: relative;
+    }
+
+    .ready-to-start__form-input {
+        width: auto;
+    }
+
+    .form__input--ready-to-start-email, .form__input--ready-to-start-btn {
+        width: auto;
+    }
+
+    .form__input--ready-to-start-email, .form__input--ready-to-start-btn {
+        margin-bottom: 0;
     }
 
     .form__input--ready-to-start-email {
-        padding-right: 17em;
+        padding-right: 15em;
+        width: 100%;
+    }
+
+    .form__input--ready-to-start-btn {
+        position: absolute;
+        right: 0;
+        padding-left: 1.6em;
+        padding-right: 1.6em;
     }
 }
 


### PR DESCRIPTION
This PR styles the ready-to-start section for the tablet layout. This involves using absolute positioning of the form button relative to the `ready-to-start__form` element in order to get the button to overlap the email input field. 

**Overview of changes made:**
- Wrap input elements with divs and add class names to div wrappers and input elements
- Change flex-direction to row for form input elements
- Add padding-right to email input element
- Position form button so it overlaps email input field
- Fix padding on form button
- Add updated HTML structure for ready-to-start section on all pages

**Tablet layout view of ready-to-start section**
![image](https://user-images.githubusercontent.com/13966892/124798659-9adcab80-df21-11eb-84a1-a1391431cef7.png)
