### PR TITLE
Style desktop of homepage intro section

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -494,6 +494,47 @@ a {
     }
 }
 
+/* Desktop Version */
+@media screen and (min-width: 1024px) {
+    .container--index-intro {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        /* border: 1px solid blue; */
+    }
+
+    .intro-content {
+        position: unset;
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        text-align: left;
+        order: 1;
+        /* border: 1px solid green; */
+        max-width: 60%;
+        margin-right: 4em;
+    }
+
+    .section-heading--intro {
+        padding: unset;
+        font-size: clamp(3rem, 5vw, 4.5rem);
+        line-height: 4.5rem;
+    }
+
+    .demo-form {
+        margin: unset;
+    }
+
+    .intro-img-container {
+        /* border: 1px solid red; */
+        order: 2;
+        max-width: 40%;
+    }
+    .intro-img {
+        width: 100%;
+    }
+}
+
 /* Who We Work With - section */
 .container--index-work {
     display: flex;


### PR DESCRIPTION
This PR styles the desktop version of the homepage intro section
- Set intro section to display flex
- Changed order of flex items
- Set width of flex items 
- Used `clamp()` to have variable section heading `font-size`
- Fixed alignment of elements within `intro-content` element

![image](https://user-images.githubusercontent.com/13966892/129391348-10d121b4-4f07-47c5-bcb7-4cc051e9973a.png)
